### PR TITLE
separate install-prereqs from pip requirements installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM themattrix/tox-base
 
 MAINTAINER Matthew Tardiff <mattrix@gmail.com>
 
-ONBUILD COPY install-prereqs*.sh requirements*.txt tox.ini /app/
 ONBUILD ARG SKIP_TOX=false
+ONBUILD COPY install-prereqs*.sh /app/
 ONBUILD RUN bash -c " \
-    if [ -f '/app/install-prereqs.sh' ]; then \
+    if [[ -f '/app/install-prereqs.sh' ]]; then \
         bash /app/install-prereqs.sh; \
-    fi && \
-    if [ $SKIP_TOX == false ]; then \
+    fi"
+
+ONBUILD COPY requirements*.txt tox.ini /app/
+ONBUILD RUN bash -c " \
+    if [[ $SKIP_TOX == false ]]; then \
         TOXBUILD=true tox; \
     fi"

--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ your project's `requirements.txt` files.
 The Dockerfile contains the following `ONBUILD` commands:
 
 ```dockerfile
-ONBUILD COPY install-prereqs*.sh requirements*.txt tox.ini /app/
 ONBUILD ARG SKIP_TOX=false
+ONBUILD COPY install-prereqs*.sh /app/
 ONBUILD RUN bash -c " \
-    if [ -f '/app/install-prereqs.sh' ]; then \
+    if [[ -f '/app/install-prereqs.sh' ]]; then \
         bash /app/install-prereqs.sh; \
-    fi && \
-    if [ $SKIP_TOX == false ]; then \
+    fi"
+
+ONBUILD COPY requirements*.txt tox.ini /app/
+ONBUILD RUN bash -c " \
+    if [[ $SKIP_TOX == false ]]; then \
         TOXBUILD=true tox; \
     fi"
 ```


### PR DESCRIPTION
I (and I guess most people) use prereqs.sh script to apt-get install packages that are needed to python requirements. Since both requirements.txt and prereqs.sh are copied in the same layer, any change to the requirements, will cause installation to the prerequisites although nothing is changed in their part.
I separated the install requirements and prerequisites to two different copy and run onbuild command.
There is a small problem - it's somewhat backwards incompatible if someone was parsing the tox.ini or the requirements.txt in the prereqs script.
Despite that, I think this is the better approach and tox is flex enough to run custom script if needed.