### PR TITLE
Mention Python 3.8 in description and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *Available on Docker Hub as [`themattrix/tox`](https://registry.hub.docker.com/u/themattrix/tox/).*
 
 This image is intended for running [tox](https://tox.readthedocs.org/en/latest/) with
-Python 2.6, 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, PyPy, and PyPy3.
+Python 2.6, 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, PyPy, and PyPy3.
 Its goal is to make testing your code against multiple Python versions quick and easy.
 The image contains several `ONBUILD` commands for initializing the tox environments with
 your project's `requirements.txt` files.
@@ -55,7 +55,7 @@ environment.
 Example `tox.ini` supporting the TOXBUILD environment variable:
 
     [tox]
-    envlist = py26,py27,py33,py34,py35,py36,py37,pypy,pypy3
+    envlist = py26,py27,py33,py34,py35,py36,py37,py38,pypy,pypy3
     skipsdist = {env:TOXBUILD:false}
 
     [testenv]
@@ -68,4 +68,5 @@ Example `tox.ini` supporting the TOXBUILD environment variable:
     commands = {env:TOXBUILD:./tests.sh --static-analysis}
 
 
-For a full example, see the [`python-pypi-template`](https://github.com/themattrix/python-pypi-template) project, which uses this image.
+For a full example, see the [`python-pypi-template`](
+https://github.com/themattrix/python-pypi-template) project, which uses this image.


### PR DESCRIPTION
Does what the title says, mentions Python 3.8 in the README. :smile: 

Please merge this PR only after https://github.com/themattrix/docker-tox-base/pull/9 is merged.